### PR TITLE
How to indicate commandline input

### DIFF
--- a/GUIDES.md
+++ b/GUIDES.md
@@ -81,16 +81,16 @@ Creating a new scenic application from scratch.
 
 Run the mix task to create a new Scenic project:
 
-    $ mix scenic.new snake
+    mix scenic.new snake
 
 Move into the newly created directory:
 
-    $ cd snake
+    cd snake
 
 Install the depedencies:
 
-    $ mix deps.get
+    mix deps.get
 
 Run the app to check everything is working:
 
-    $ mix scenic.run
+    mix scenic.run

--- a/GUIDES.md
+++ b/GUIDES.md
@@ -2,11 +2,11 @@
 
 Material for building the workshop tutorial.
 
-## Concepts 
+## Concepts
 
-### Elxir Basics
+### Elixir Basics
 
-We need to explain some Elixir basics like the data structures we use. We should have a look at the [Elixir Girls Elixir Beginners Guide](https://elixirgirls.com/guides/elixir-beginners-guide.html) for this. 
+We need to explain some Elixir basics like the data structures we use. We should have a look at the [Elixir Girls Elixir Beginners Guide](https://elixirgirls.com/guides/elixir-beginners-guide.html) for this.
 
 A first collection things we need to explain (very incomplete):
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build a Snake game to learn Elixir
 
-This tutorial is about building a Snake game with Scenic to teach Elixir. 
+This tutorial is about building a Snake game with Scenic to teach Elixir.
 
 The tutorial is heavily based on the following article: [Getting started with Scenic in Elixir — Crafting a simple snake game].
 
@@ -20,31 +20,31 @@ Set up the project in order to view and run sample solutions for each step of th
 
 1. Install Erlang and Elixir on your machine - the required versions can be found in the `.tool-versions` file:
 
-        $ cat .tool-versions
+        cat .tool-versions
 
   _(In case you're using the [asdf version manager](https://github.com/asdf-vm/asdf), install the respective plugins for Erlang/Elixir and run `asdf install`.)_
 
 1. Install Open GL libraries for _(for [scenic_new](https://github.com/boydm/scenic_new))_
 
   On macOS 🍏:
-        
-        $ brew install glfw3 glew pkg-config
+
+         brew install glfw3 glew pkg-config
 
   On Ubuntu 18 🐧:
 
-        $ sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
+         sudo apt-get install pkgconf libglfw3 libglfw3-dev libglew2.0 libglew-dev
 
   _(See https://github.com/boydm/scenic_new#install-prerequisites for details on other operating systems.)_
 
 1. Install the `scenic.new` mix task _(Mix task to easily generate a Scenic app)_:
 
-        $ mix archive.install hex scenic_new
+         mix archive.install hex scenic_new
 
 ### Running
 
 Run the game with:
 
-    $ mix scenic.run
+    mix scenic.run
 
 ### Files
 


### PR DESCRIPTION
In #2 @klappradla proposed not to use `$` to indicate command line input. I moved the changes to this PR for further discussion.

[Original note](https://github.com/codecurious-bln/elixir_snake/pull/2#issue-332807152) from @klappradla:

> Note: I removed all the $ signs before terminal input as I feel that distinguishing between editor an terminal input is more a problem of formulating or styling the text. Over the years, I've seen the majority of people taking part in Rails Girls workshops struggle with the $ as a) the convention of this indicating a terminal prompt was not known to them (they would input the $ character as well) and b) it makes copy pasting harder.
☝️ again, feel free to disagree, simply my personal opinion.
