### PR TITLE
Bump Erlang/Elixir versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.9.0
-erlang 22.0.4
+elixir 1.9.2
+erlang 22.1.4

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Set up the project in order to view and run sample solutions for each step of th
 
 ### Installation
 
-1. Install Erlang and Elixir on your machine - the required versions can be found in the `.tool-versions` file:
-
-        $ cat .tool-versions
+1. Install Erlang and Elixir on your machine. Scenic requires Erlang/OTP 21 (or newer) and Elixir 1.7 (or newer).
 
   _(In case you're using the [asdf version manager](https://github.com/asdf-vm/asdf), install the respective plugins for Erlang/Elixir and run `asdf install`.)_
 


### PR DESCRIPTION
Erlang 22.0.4 doesn't build on macOS Catalina. This is what I was getting when trying to run `asdf install`:

```
$ asdf install
elixir 1.9.0 is already installed
Downloading kerl...

Extracting source code
mv: rename ./otp-OTP-22.0.4 to /Users/angelika/.asdf/plugins/erlang/kerl-home/builds/asdf_22.0.4/otp_src_22.0.4/otp-OTP-22.0.4: Directory not empty
Building Erlang/OTP 22.0.4 (asdf_22.0.4), please wait...
Configure options have changed. Reconfiguring...
DOCUMENTATION INFORMATION (See: /Users/angelika/.asdf/plugins/erlang/kerl-home/builds/asdf_22.0.4/otp_build_22.0.4.log)
 * documentation  : 
 *                  fop is missing.
 *                  Using fakefop to generate placeholder PDF files.

Build failed.
/bin/sh: line 1: 38871 Segmentation fault: 11  erlc -W +debug_info +inline +warn_unused_import +warn_export_vars -Werror -o../ebin hipe_rtl_arch.erl
make[3]: *** [../ebin/hipe_rtl_symbolic.beam] Error 139
make[3]: *** [../ebin/hipe_rtl_arch.beam] Error 139
/bin/sh: line 1: 38869 Segmentation fault: 11  erlc -W +debug_info +inline +warn_unused_import +warn_export_vars -Werror -o../ebin hipe_rtl_binary_match.erl
/bin/sh: line 1: 38893 Segmentation fault: 11  erlc -W +debug_info +inline +warn_unused_import +warn_export_vars -Werror -o../ebin hipe_rtl_cfg.erl
make[3]: *** [../ebin/hipe_rtl_cfg.beam] Error 139
make[3]: *** [../ebin/hipe_rtl_binary_match.beam] Error 139
make[2]: *** [opt] Error 2
make[1]: *** [opt] Error 2
make: *** [secondary_bootstrap_build] Error 2

Please see /Users/angelika/.asdf/plugins/erlang/kerl-home/builds/asdf_22.0.4/otp_build_22.0.4.log for full details.
```

According to this issue https://github.com/asdf-vm/asdf-erlang/issues/116, the problem is resolved in asdf-erlang 22.1.4. I was able to install that version.

Bumping Elixir was not technically necessary but why not? 🤷‍♂ 