### PR TITLE
Add intro section for tutorial

### DIFF
--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -25,7 +25,13 @@ A first collection things we need to explain (very incomplete):
 
 ## Tutorial
 
-### 0. Prerequisites
+We want to learn more about the [Elixir](https://elixir-lang.org) programming language by building a fun game together: **snake** - a cult game from mobile phones in the 90s 🕹
+
+![snake game on a nokia phone](https://media.giphy.com/media/ZYOybCzZvpcY0/giphy.gif)
+
+The game works as follows:  
+> The player controls a moving snake which has to "eat" as many items as possible by running into them with its head. Each item makes the snake grow longer and the game is lost when the head runs into the tail.
+
 
 - explain what Scenic is
 - explain what `mix` is
@@ -34,6 +40,11 @@ A first collection things we need to explain (very incomplete):
     - rake is only a task runner
 - install the `scenic_new` mix task
   - install an archive locally
+
+
+### 0. Prerequisites
+
+- make sure all tools are set up
 
 
 Navigate into your personal projects directory or wherever else you want to keep the application.

--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -48,9 +48,7 @@ If your version is lower than `1.9.x`, either update to a more recent version or
 
 Next, we'll install some `mix` tasks to help us build a `Scenic` application. [mix](https://hexdocs.pm/mix/Mix.html) is a tool that comes with Elixir to help developing apps and manage their dependencies. It is similar to e.g. `npm` in JavaScript (don't worry if you don't know that).
 
-The tasks in the `scenic_new` archive have some prerequisites. Head to the [instructions](https://github.com/boydm/scenic_new#install-prerequisites) for your operating system and install them first.and find the instructions for your operating system.
-
-The `scenic_new` tasks require some additional libraries installed on your computer. See the [install prerequisites](https://github.com/boydm/scenic_new#install-prerequisites) for installation instructions for your operating system.
+Specifically, we will use the `scenic_new` tasks which require some additional libraries installed on your computer. See the [install prerequisites](https://github.com/boydm/scenic_new#install-prerequisites) for installation instructions for your operating system.
 
 Once everything is set up, you can install the tasks via `mix`:
 

--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -25,15 +25,18 @@ A first collection things we need to explain (very incomplete):
 
 ## Tutorial
 
-We want to learn more about the [Elixir](https://elixir-lang.org) programming language by building a fun game together: **snake** - a cult game from mobile phones in the 90s 🕹
+We want to learn more about the [Elixir](https://elixir-lang.org) programming language by building a fun game together: **snake** - a cult game from mobile phones in the 1990s 🕹
 
 ![snake game on a nokia phone](https://media.giphy.com/media/ZYOybCzZvpcY0/giphy.gif)
 
 The game works as follows:  
 > The player controls a moving snake which has to "eat" as many items as possible by running into them with its head. Each item makes the snake grow longer and the game is lost when the head runs into the tail.
 
+We will implement the game using [Scenic](https://github.com/boydm/scenic), a library for building native macOS or Linux applications with graphical user interfaces in Elixir.
 
-- explain what Scenic is
+So let's build a fun game together!
+
+
 - explain what `mix` is
   - run `mix help` to see what commands are available and what they do
   - use mix as a task runner here (compare to npm, yarn)

--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -36,25 +36,33 @@ We will implement the game using [Scenic](https://github.com/boydm/scenic), a li
 
 So let's build a fun game together!
 
+### 0. Getting ready
 
-- explain what `mix` is
-  - run `mix help` to see what commands are available and what they do
-  - use mix as a task runner here (compare to npm, yarn)
-    - rake is only a task runner
-- install the `scenic_new` mix task
-  - install an archive locally
+We first need to make sure we have Elixir installed on our computer. [Installing Elixir](https://elixir-lang.org/install.html) has installation instructions for all tastes and operating systems.
 
+Once installed, check the version by running this command in your terminal:
 
-### 0. Prerequisites
+    $ elixir --version
 
-- make sure all tools are set up
+If your version is lower than `1.9.x`, either update to a more recent version or ask a coach for help.
 
+Next we'll install some `mix` tasks to help us build a `Scenic` application. [mix](https://hexdocs.pm/mix/Mix.html) is a tool that comes with Elixir to help developing apps and manage their dependencies. It it similar to e.g. `npm` in JavaScript (don't worry if you don't know that).
 
-Navigate into your personal projects directory or wherever else you want to keep the application.
+The tasks in the `scenic_new` archive have some prerequisites. Head to the [instructions](https://github.com/boydm/scenic_new#install-prerequisites) for your operating system and install them first.and find the instructions for your operating system.
+
+The `scenic_new` tasks require some additional libraries installed on your computer. See the [install prerequisites](https://github.com/boydm/scenic_new#install-prerequisites) for installation instructions for your operating system.
+
+Once everything is set up, you can install the tasks via `mix`:
+
+    $ mix archive.install hex scenic_new
+
+Now we are prepared to start building our Scenic application!
+
+Navigate into your personal projects directory _(or wherever you want to keep the files for the tutorial)_ and then let's get started 🚀
 
 ### 1. Create a scenic app
 
-First off we need to create a new Scenic application using our previously installed `scenic_new` mix task. We are going to build a snake game, so let's call our project `snake`. The `scenic_new` package gives us the handy `scenic.new` task which can be used to bootstrap a new Scenic application.
+First off we'll to create a new Scenic application using our previously installed `scenic_new` mix task. We are building a snake game, so let's call our project `snake`. The `scenic_new` package gives us the handy `scenic.new` task which can be used to bootstrap a new Scenic application.
 
 The task makes some assumptions about the typical structure of a Scenic application. It will generate a skeleton for our snake app with all directories and files already in place. This is "boilerplate" code we would otherwise need to write by hand.
 

--- a/docs/GUIDES.md
+++ b/docs/GUIDES.md
@@ -46,7 +46,7 @@ Once installed, check the version by running this command in your terminal:
 
 If your version is lower than `1.9.x`, either update to a more recent version or ask a coach for help.
 
-Next we'll install some `mix` tasks to help us build a `Scenic` application. [mix](https://hexdocs.pm/mix/Mix.html) is a tool that comes with Elixir to help developing apps and manage their dependencies. It it similar to e.g. `npm` in JavaScript (don't worry if you don't know that).
+Next, we'll install some `mix` tasks to help us build a `Scenic` application. [mix](https://hexdocs.pm/mix/Mix.html) is a tool that comes with Elixir to help developing apps and manage their dependencies. It is similar to e.g. `npm` in JavaScript (don't worry if you don't know that).
 
 The tasks in the `scenic_new` archive have some prerequisites. Head to the [instructions](https://github.com/boydm/scenic_new#install-prerequisites) for your operating system and install them first.and find the instructions for your operating system.
 
@@ -62,7 +62,7 @@ Navigate into your personal projects directory _(or wherever you want to keep th
 
 ### 1. Create a scenic app
 
-First off we'll to create a new Scenic application using our previously installed `scenic_new` mix task. We are building a snake game, so let's call our project `snake`. The `scenic_new` package gives us the handy `scenic.new` task which can be used to bootstrap a new Scenic application.
+First off we'll create a new Scenic application using our previously installed `scenic_new` mix task. We are building a snake game, so let's call our project `snake`. The `scenic_new` package gives us the handy `scenic.new` task which can be used to bootstrap a new Scenic application.
 
 The task makes some assumptions about the typical structure of a Scenic application. It will generate a skeleton for our snake app with all directories and files already in place. This is "boilerplate" code we would otherwise need to write by hand.
 


### PR DESCRIPTION
This adds the intro section for the tutorial, also addressing #10. It includes:
- a brief explanation what the tutorial is about
- a brief explanation what "snake" the game is
- a quick walk through for installing all prerequisites _(Elixir, the `scenic_new` tasks)_

Rather than diving into the details on how to install Elixir or the Open GL libraries for the `scenic_new` tasks, I just pointed to the installation guides of the respective things on the internet. Given we'll have an experienced group, an installation party the day before, an intro to Elixir at the beginning of the workshop and coaches around, I feel like this is a) good enough for the tutorial and b) easier to maintain.

In case we need a separate, more detailed guide for setting up a development environment, I would put this into a tutorial for the installation party.

Feedback welcome 👋 