### PR TITLE
Add editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# For consistent formatting style https://EditorConfig.org
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This adds a simple [editorconfig]()https://editorconfig.org/) file to the root of the project to ensure consistent styles for multiple developers working on the project and using different operating systems and editors.

This is for now simple ensuring we're trimming whitespace in non-Markdown files, use unix line endings and have a blank line at the end of a file.

Feel free to disagree on these options - this is just a suggestion.